### PR TITLE
fix draw command for hellosoot tutorial

### DIFF
--- a/docs/1/README.md
+++ b/docs/1/README.md
@@ -84,7 +84,7 @@ The branch statements control the flow of the execution of statements. All possi
 You can draw this image by running
 
 ```
-./gradlew run --args='draw'
+./gradlew run --args="HelloSoot draw"
 ```
 
 ![Control Flow Graph](https://github.com/noidsirius/SootTutorial/blob/master/docs/1/images/cfg-number.png)


### PR DESCRIPTION
Fix a small typo in hellosoot tutorial:
```
➜ SootTutorial (master) ✗ ./gradlew run --args='draw'

> Task :run
The class 'draw' does not exists or does not have a main method.

BUILD SUCCESSFUL in 1s
2 actionable tasks: 1 executed, 1 up-to-date
```